### PR TITLE
fix: types issue

### DIFF
--- a/components/bottom-tabs.tsx
+++ b/components/bottom-tabs.tsx
@@ -1,7 +1,4 @@
-import {
-  createNativeBottomTabNavigator,
-  // BottomSheetNavigationOptions,
-} from "react-native-bottom-tabs/react-navigation";
+import { createNativeBottomTabNavigator } from "react-native-bottom-tabs/react-navigation";
 
 import { withLayoutContext } from "expo-router";
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-bottom-tabs": "^0.0.7",
+    "react-native-bottom-tabs": "^0.0.8",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",


### PR DESCRIPTION
This PR bumps bottom-tabs library to 0.0.8 (which fixes types issue). 

